### PR TITLE
Plumb malloc failures up through the API reliably.

### DIFF
--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -132,7 +132,7 @@ extern "C" {
  *        might already have been added to the low level error code.
  */
 #define MBEDTLS_ERROR_ADD( high, low ) \
-        mbedtls_error_add( high, ( low ) | ~0x7f, __FILE__, __LINE__ )
+        mbedtls_error_add( high, MBEDTLS_LOW_LEVEL_ERROR( low ), __FILE__, __LINE__ )
 
 #if defined(MBEDTLS_TEST_HOOKS)
 /**

--- a/include/mbedtls/error.h
+++ b/include/mbedtls/error.h
@@ -116,13 +116,23 @@ extern "C" {
 #define MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED -0x0072
 
 /**
+ * \brief Gets only the low-level error code from an error code.
+ *        This is the low 7 bits of the error code. Error codes
+ *        are negative, so this returns a small negative number.
+ *        This doesn't work on 0 (no error).
+ */
+#define MBEDTLS_LOW_LEVEL_ERROR( error_code ) \
+        ( ( error_code ) | ~0x7f )
+
+/**
  * \brief Combines a high-level and low-level error code together.
  *
  *        Wrapper macro for mbedtls_error_add(). See that function for
- *        more details.
+ *        more details. This wrapper removes any high level error that
+ *        might already have been added to the low level error code.
  */
 #define MBEDTLS_ERROR_ADD( high, low ) \
-        mbedtls_error_add( high, low, __FILE__, __LINE__ )
+        mbedtls_error_add( high, ( low ) | ~0x7f, __FILE__, __LINE__ )
 
 #if defined(MBEDTLS_TEST_HOOKS)
 /**

--- a/library/ecdh.c
+++ b/library/ecdh.c
@@ -185,7 +185,7 @@ static int ecdh_setup_internal( mbedtls_ecdh_context_mbed *ctx,
     ret = mbedtls_ecp_group_load( &ctx->grp, grp_id );
     if( ret != 0 )
     {
-        return( MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE );
+        return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_ECP_FEATURE_UNAVAILABLE, ret ) );
     }
 
     return( 0 );

--- a/library/pkparse.c
+++ b/library/pkparse.c
@@ -522,7 +522,7 @@ static int pk_get_rsapubkey( unsigned char **p,
 
     if( ( ret = mbedtls_rsa_import_raw( rsa, *p, len, NULL, 0, NULL, 0,
                                         NULL, 0, NULL, 0 ) ) != 0 )
-        return( MBEDTLS_ERR_PK_INVALID_PUBKEY );
+        return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_PK_INVALID_PUBKEY, ret ) );
 
     *p += len;
 
@@ -532,14 +532,14 @@ static int pk_get_rsapubkey( unsigned char **p,
 
     if( ( ret = mbedtls_rsa_import_raw( rsa, NULL, 0, NULL, 0, NULL, 0,
                                         NULL, 0, *p, len ) ) != 0 )
-        return( MBEDTLS_ERR_PK_INVALID_PUBKEY );
+        return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_PK_INVALID_PUBKEY, ret ) );
 
     *p += len;
 
-    if( mbedtls_rsa_complete( rsa ) != 0 ||
-        mbedtls_rsa_check_pubkey( rsa ) != 0 )
+    if( ( ret = mbedtls_rsa_complete( rsa ) ) != 0 ||
+        ( ret = mbedtls_rsa_check_pubkey( rsa ) ) != 0 )
     {
-        return( MBEDTLS_ERR_PK_INVALID_PUBKEY );
+        return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_PK_INVALID_PUBKEY, ret ) );
     }
 
     if( *p != end )

--- a/library/ssl_tls12_client.c
+++ b/library/ssl_tls12_client.c
@@ -2269,14 +2269,16 @@ start_processing:
         ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_DHE_PSK ||
         ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK )
     {
-        if( ssl_parse_server_psk_hint( ssl, &p, end ) != 0 )
+        ret = ssl_parse_server_psk_hint( ssl, &p, end );
+        if( ret != 0 )
         {
+
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message" ) );
             mbedtls_ssl_send_alert_message(
                 ssl,
                 MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                 MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR );
-            return( MBEDTLS_ERR_SSL_DECODE_ERROR );
+            return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_SSL_DECODE_ERROR, ret ) );
         }
     } /* FALLTHROUGH */
 #endif /* MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED */
@@ -2294,14 +2296,15 @@ start_processing:
     if( ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_DHE_RSA ||
         ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_DHE_PSK )
     {
-        if( ssl_parse_server_dh_params( ssl, &p, end ) != 0 )
+        ret = ssl_parse_server_dh_params( ssl, &p, end );
+        if( ret != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message" ) );
             mbedtls_ssl_send_alert_message(
                 ssl,
                 MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                 MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER );
-            return( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
+            return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER, ret ) );
         }
     }
     else
@@ -2314,14 +2317,15 @@ start_processing:
         ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_PSK ||
         ciphersuite_info->key_exchange == MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA )
     {
-        if( ssl_parse_server_ecdh_params( ssl, &p, end ) != 0 )
+        ret = ssl_parse_server_ecdh_params( ssl, &p, end );
+        if( ret != 0 )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message" ) );
             mbedtls_ssl_send_alert_message(
                 ssl,
                 MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                 MBEDTLS_SSL_ALERT_MSG_ILLEGAL_PARAMETER );
-            return( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER );
+            return( MBEDTLS_ERROR_ADD( MBEDTLS_ERR_SSL_ILLEGAL_PARAMETER, ret ) );
         }
     }
     else


### PR DESCRIPTION
This fixes some cases where a malloc failure gets converted into a non-intermittet error message like failed certificate parsing or verification.

